### PR TITLE
Development

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -105,5 +105,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": ["faces-cdk-project"]
 }


### PR DESCRIPTION
Fix to exclude CDK project directory from TypeScript compilation /build of TS files in /src rootDir of main project directory.